### PR TITLE
Declare data with var, so there is no global leak.

### DIFF
--- a/lib/injectr.js
+++ b/lib/injectr.js
@@ -9,6 +9,7 @@ module.exports = function (file, descriptor, all) {
     var context, // the module-level context the file will run under
         libPath, // the resolved path of the lib to require
         mocks, // where the mock objects are stored
+        data, // file content
         script; // the vm.Script object created from the file contents
 
     // descriptor is an optional parameter


### PR DESCRIPTION
Some testing frameworks are testing for leaks (e.g. mocha). In these cases the tests fail.
