### PR TITLE
Handle coffee script properly

### DIFF
--- a/lib/injectr.js
+++ b/lib/injectr.js
@@ -5,7 +5,19 @@
 var cache = {},
     fs = require('fs'),
     path = require('path'),
-    vm = require('vm');
+    vm = require('vm'),
+    load;
+
+load = function(file) {
+    var raw = fs.readFileSync(file, 'utf8'),
+        compiled;
+    if (file.match(/\.js$/)) {
+        compiled = raw;
+    } else if (file.match(/\.coffee$/)) {
+        compiled = require('coffee-script').compile(raw, {filename: file});
+    }
+    return compiled;
+}
 
 module.exports = function (file, descriptor, all) {
     var context, // the module-level context the file will run under
@@ -70,7 +82,7 @@ module.exports = function (file, descriptor, all) {
     if (!cache[file]) {
         // use sync version because `require` is sync, so that's what the user
         // expects
-        data = fs.readFileSync(file, 'utf8');
+        data = load(file);
         cache[file] = vm.createScript(data, file);
     }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "node" : "0.6.x"
     },
     "devDependencies" : {
-        "qunit" : ">=0.2"
+        "qunit" : ">=0.2",
+        "coffee-script": ">=1.2.0"
     },
     "scripts" : {
         "test" : "make test"

--- a/test/pretend-scripts/require-export-test.coffee
+++ b/test/pretend-scripts/require-export-test.coffee
@@ -1,0 +1,1 @@
+module.exports.exportTest = require './export-test'

--- a/test/pretend-scripts/require-fs.coffee
+++ b/test/pretend-scripts/require-fs.coffee
@@ -1,0 +1,1 @@
+module.exports.fs = require 'fs'

--- a/test/tests.js
+++ b/test/tests.js
@@ -15,12 +15,19 @@ test('will require files correctly', function () {
 test('will require modules correctly', function () {
     var requiredPath = injectr('./test/pretend-scripts/require-path.js');
     deepEqual(requiredPath.path, path);
+
+    var requiredPath = injectr('./test/pretend-scripts/require-fs.coffee');
+    deepEqual(requiredPath.fs, fs);
 });
 test('will inject mocks', function () {
     var requiredPath = injectr('./test/pretend-scripts/require-path.js', {
         path : 'this is a mock'
     });
     equal(requiredPath.path, 'this is a mock');
+    var requiredCoffeePath = injectr('./test/pretend-scripts/require-fs.coffee', {
+        fs : 'this is a mock'
+    });
+    equal(requiredCoffeePath.fs, 'this is a mock');
     var requiredStaticVars = injectr(
         './test/pretend-scripts/require-static-vars.js',
         {
@@ -29,6 +36,14 @@ test('will inject mocks', function () {
             }
         });
     equal(requiredStaticVars.staticVars.one, 'a mock value');
+    var requiredExportTest = injectr(
+        './test/pretend-scripts/require-export-test.coffee',
+        {
+            './export-test' : {
+                one : 'a mock value'
+            }
+        });
+    equal(requiredExportTest.exportTest.one, 'a mock value');
 });
 test("will export values properly", function () {
     var exportTest = injectr('./test/pretend-scripts/export-test.js');


### PR DESCRIPTION
Compile coffee script files (to javascript) before handing them to vm.createScript.
