### PR TITLE
requires in injected modules starting with ../ would not work

### DIFF
--- a/lib/injectr.js
+++ b/lib/injectr.js
@@ -61,7 +61,7 @@ module.exports = function (file, descriptor, all) {
         if (mocks.hasOwnProperty(lib)) {
             return mocks[lib];
         }
-        if (lib.indexOf('./') === 0) {
+        if (lib.indexOf('./') === 0 || lib.indexOf('../') === 0) {
             return require(path.resolve(path.join(path.dirname(file), lib)));
         }
         return require(lib);

--- a/test/pretend-scripts/dir/require-static-vars.js
+++ b/test/pretend-scripts/dir/require-static-vars.js
@@ -1,0 +1,1 @@
+module.exports.staticVars = require('../static-vars.js');

--- a/test/tests.js
+++ b/test/tests.js
@@ -11,6 +11,10 @@ test('will require files correctly', function () {
         './test/pretend-scripts/require-static-vars.js');
     equal(requiredStaticVars.staticVars.one, 'this is a string');
     equal(requiredStaticVars.staticVars.two, 2);
+    requiredStaticVars = injectr(
+        './test/pretend-scripts/dir/require-static-vars.js');
+    equal(requiredStaticVars.staticVars.one, 'this is a string');
+    equal(requiredStaticVars.staticVars.two, 2);
 });
 test('will require modules correctly', function () {
     var requiredPath = injectr('./test/pretend-scripts/require-path.js');


### PR DESCRIPTION
file ./dir/foo.js

```
require('../bar')
```

file ./bar.js

```
module.exports = 'something'
```

file ./baz.js

```
require('injectr')('./dir/foo.js') // says cannot find ../bar
```
